### PR TITLE
MapView widget reference should use the widget name

### DIFF
--- a/apidoc/arcgis.gis.html
+++ b/apidoc/arcgis.gis.html
@@ -397,7 +397,7 @@ as well as the results of your analysis. To create a new map, call the map() met
 <dl class="method">
 <dt id="arcgis.gis.GIS.map">
 <code class="descname">map</code><span class="sig-paren">(</span><em>location=None</em>, <em>zoomlevel=None</em><span class="sig-paren">)</span><a class="headerlink" href="#arcgis.gis.GIS.map" title="Permalink to this definition">¶</a></dt>
-<dd><p>Creates a map widget centered at the location (Address or (lat, long) tuple)
+<dd><p>Creates a MapView widget to display a map centered at the location (Address or (lat, long) tuple)
 with the specified zoom-level(integer). If an Address is provided, it is geocoded
 using the GIS&#8217;s configured geocoders and if a match is found, the geographic
 extent of the matched address is used as the map extent. If a zoomlevel is also


### PR DESCRIPTION
The current text is a little confusing for the documentation since it had me hunting for a `Map` widget. However, the widget is named `MapView`.

Not sure about the right way to improve this, but perhaps this suggestion will work.